### PR TITLE
"undefined" is not a reserved keyword

### DIFF
--- a/lib/observer.js
+++ b/lib/observer.js
@@ -26,7 +26,7 @@ EventBroker.prototype.publish = function(subject){
   var subscribers = this.get(subject),
       args = Array.prototype.slice.call(arguments,1);
 
-  args.splice(0,0, undefined);
+  args.splice(0,0, null);
 
   for(var i = -1, len=subscribers.length; ++i < len; ){
     setTimeout(Function.prototype.bind.apply(subscribers[i], args), 0);   


### PR DESCRIPTION
_undefined_ is not a reserved keyword. Thus, it could actually be defined as something in an outer scope. Better to use something like _null_ which actually is a reserved keyword and yields the same result.
